### PR TITLE
Change access modifers to allow use in library

### DIFF
--- a/DataversePluginTemplate/Prebuild/EntityPreprocessingPlugin.cs
+++ b/DataversePluginTemplate/Prebuild/EntityPreprocessingPlugin.cs
@@ -11,7 +11,7 @@ namespace DataversePluginTemplate.Prebuild
         public EntityPreprocessingPlugin(string unsecureConfiguration, string secureConfiguration)
             : base(unsecureConfiguration, secureConfiguration) { }
 
-        public abstract IEnumerable<(string attribut, object value)> Process(PluginContext context, Entity entity);
+        protected abstract IEnumerable<(string attribut, object value)> Process(PluginContext context, Entity entity);
 
         
         protected sealed override void OnCreate(PluginContext context, Entity entity)

--- a/DataversePluginTemplate/Prebuild/RenamePlugin.cs
+++ b/DataversePluginTemplate/Prebuild/RenamePlugin.cs
@@ -24,9 +24,9 @@ namespace DataversePluginTemplate.Prebuild
             _nameColumn = nameColumn;
         }
 
-        internal abstract IEnumerable<string> BuildName(PluginContext context, Entity entity);
+        protected abstract IEnumerable<string> BuildName(PluginContext context, Entity entity);
 
-        public sealed override IEnumerable<(string attribut, object value)> Process(PluginContext context, Entity entity)
+        protected sealed override IEnumerable<(string attribut, object value)> Process(PluginContext context, Entity entity)
         {
             var nameParts = BuildName(context, entity)
                 .GetEnumerator();

--- a/DataversePluginTemplate/Queries/Columns.cs
+++ b/DataversePluginTemplate/Queries/Columns.cs
@@ -1,6 +1,6 @@
 ﻿namespace DataversePluginTemplate.Queries
 {
-    internal enum Columns
+    public enum Columns
     {
         None,
         All,

--- a/DataversePluginTemplate/Queries/FilterContext.cs
+++ b/DataversePluginTemplate/Queries/FilterContext.cs
@@ -10,7 +10,7 @@ namespace DataversePluginTemplate.Queries
     /// Wrapper for handleing filter operations in queries.
     /// <seealso cref="QueryContext"/>.
     /// </summary>
-    internal sealed class FilterContext
+    public sealed class FilterContext
     {
         private readonly FilterExpression _filterExpression;
 
@@ -21,100 +21,100 @@ namespace DataversePluginTemplate.Queries
 
         #region - Methoden für Condtions -
 
-        internal FilterContext Equals(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.Equal);
-        internal FilterContext NotEqual(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NotEqual);
-        internal FilterContext Greater(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.GreaterThan);
-        internal FilterContext LessThan(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.LessThan);
-        internal FilterContext GreaterEqual(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.GreaterEqual);
-        internal FilterContext LessEqual(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.LessEqual);
-        internal FilterContext Like(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.Like);
-        internal FilterContext NotLike(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NotLike);
-        internal FilterContext In(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.In);
-        internal FilterContext NotIn(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NotIn);
-        internal FilterContext Between(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.Between);
-        internal FilterContext NotBetween(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NotBetween);
-        internal FilterContext IsNull(string columnName) => HandleInternal(columnName, ConditionOperator.Null);
-        internal FilterContext IsNotNull(string columnName) => HandleInternal(columnName, ConditionOperator.NotNull);
-        internal FilterContext Yesterday(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.Yesterday);
-        internal FilterContext Today(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.Today);
-        internal FilterContext Tomorrow(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.Tomorrow);
-        internal FilterContext Last7Days(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.Last7Days);
-        internal FilterContext Next7Days(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.Next7Days);
-        internal FilterContext LastWeek(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.LastWeek);
-        internal FilterContext ThisWeek(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.ThisWeek);
-        internal FilterContext NextWeek(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.NextWeek);
-        internal FilterContext LastMonth(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.LastMonth);
-        internal FilterContext ThisMonth(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.ThisMonth);
-        internal FilterContext NextMonth(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.NextMonth);
-        internal FilterContext On(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.On);
-        internal FilterContext OnOrBefore(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.OnOrBefore);
-        internal FilterContext OnOrAfter(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.OnOrAfter);
-        internal FilterContext LastYear(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.LastYear);
-        internal FilterContext ThisYear(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.ThisYear);
-        internal FilterContext NextYear(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.NextYear);
-        internal FilterContext LastXHours(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.LastXHours);
-        internal FilterContext NextXHours(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NextXHours);
-        internal FilterContext LastXDays(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.LastXDays);
-        internal FilterContext NextXDays(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NextXDays);
-        internal FilterContext LastXWeeks(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.LastXWeeks);
-        internal FilterContext NextXWeeks(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NextXWeeks);
-        internal FilterContext LastXMonths(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.LastXMonths);
-        internal FilterContext NextXMonths(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NextXMonths);
-        internal FilterContext LastXYears(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.LastXYears);
-        internal FilterContext NextXYears(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NextXYears);
-        internal FilterContext EqualUserId(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.EqualUserId);
-        internal FilterContext NotEqualUserId(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NotEqualUserId);
-        internal FilterContext EqualBusinessId(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.EqualBusinessId);
-        internal FilterContext NotEqualBusinessId(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NotEqualBusinessId);
-        internal FilterContext ChildOf(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.ChildOf);
-        internal FilterContext Mask(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.Mask);
-        internal FilterContext NotMask(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NotMask);
-        internal FilterContext MasksSelect(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.MasksSelect);
-        internal FilterContext Contains(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.Contains);
-        internal FilterContext DoesNotContain(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.DoesNotContain);
-        internal FilterContext EqualUserLanguage(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.EqualUserLanguage);
-        internal FilterContext NotOn(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NotOn);
-        internal FilterContext OlderThanXMonths(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.OlderThanXMonths);
-        internal FilterContext BeginsWith(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.BeginsWith);
-        internal FilterContext DoesNotBeginWith(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.DoesNotBeginWith);
-        internal FilterContext EndsWith(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.EndsWith);
-        internal FilterContext DoesNotEndWith(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.DoesNotEndWith);
-        internal FilterContext ThisFiscalYear(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.ThisFiscalYear);
-        internal FilterContext ThisFiscalPeriod(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.ThisFiscalPeriod);
-        internal FilterContext NextFiscalYear(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.NextFiscalYear);
-        internal FilterContext NextFiscalPeriod(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.NextFiscalPeriod);
-        internal FilterContext LastFiscalYear(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.LastFiscalYear);
-        internal FilterContext LastFiscalPeriod(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.LastFiscalPeriod);
-        internal FilterContext LastXFiscalYears(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.LastXFiscalYears);
-        internal FilterContext LastXFiscalPeriods(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.LastXFiscalPeriods);
-        internal FilterContext NextXFiscalYears(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NextXFiscalYears);
-        internal FilterContext NextXFiscalPeriods(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NextXFiscalPeriods);
-        internal FilterContext InFiscalYear(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.InFiscalYear);
-        internal FilterContext InFiscalPeriod(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.InFiscalPeriod);
-        internal FilterContext InFiscalPeriodAndYear(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.InFiscalPeriodAndYear);
-        internal FilterContext InOrBeforeFiscalPeriodAndYear(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.InOrBeforeFiscalPeriodAndYear);
-        internal FilterContext InOrAfterFiscalPeriodAndYear(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.InOrAfterFiscalPeriodAndYear);
-        internal FilterContext EqualUserTeams(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.EqualUserTeams);
-        internal FilterContext EqualUserOrUserTeams(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.EqualUserOrUserTeams);
-        internal FilterContext Under(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.Under);
-        internal FilterContext NotUnder(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NotUnder);
-        internal FilterContext UnderOrEqual(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.UnderOrEqual);
-        internal FilterContext Above(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.Above);
-        internal FilterContext AboveOrEqual(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.AboveOrEqual);
-        internal FilterContext EqualUserOrUserHierarchy(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.EqualUserOrUserHierarchy);
-        internal FilterContext EqualUserOrUserHierarchyAndTeams(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.EqualUserOrUserHierarchyAndTeams);
-        internal FilterContext OlderThanXYears(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.OlderThanXYears);
-        internal FilterContext OlderThanXWeeks(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.OlderThanXWeeks);
-        internal FilterContext OlderThanXDays(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.OlderThanXDays);
-        internal FilterContext OlderThanXHours(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.OlderThanXHours);
-        internal FilterContext OlderThanXMinutes(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.OlderThanXMinutes);
-        internal FilterContext ContainValues(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.ContainValues);
-        internal FilterContext DoesNotContainValues(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.DoesNotContainValues);
-        internal FilterContext EqualRoleBusinessId(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.EqualRoleBusinessId);
+        public FilterContext Equals(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.Equal);
+        public FilterContext NotEqual(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NotEqual);
+        public FilterContext Greater(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.GreaterThan);
+        public FilterContext LessThan(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.LessThan);
+        public FilterContext GreaterEqual(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.GreaterEqual);
+        public FilterContext LessEqual(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.LessEqual);
+        public FilterContext Like(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.Like);
+        public FilterContext NotLike(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NotLike);
+        public FilterContext In(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.In);
+        public FilterContext NotIn(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NotIn);
+        public FilterContext Between(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.Between);
+        public FilterContext NotBetween(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NotBetween);
+        public FilterContext IsNull(string columnName) => HandleInternal(columnName, ConditionOperator.Null);
+        public FilterContext IsNotNull(string columnName) => HandleInternal(columnName, ConditionOperator.NotNull);
+        public FilterContext Yesterday(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.Yesterday);
+        public FilterContext Today(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.Today);
+        public FilterContext Tomorrow(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.Tomorrow);
+        public FilterContext Last7Days(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.Last7Days);
+        public FilterContext Next7Days(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.Next7Days);
+        public FilterContext LastWeek(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.LastWeek);
+        public FilterContext ThisWeek(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.ThisWeek);
+        public FilterContext NextWeek(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.NextWeek);
+        public FilterContext LastMonth(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.LastMonth);
+        public FilterContext ThisMonth(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.ThisMonth);
+        public FilterContext NextMonth(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.NextMonth);
+        public FilterContext On(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.On);
+        public FilterContext OnOrBefore(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.OnOrBefore);
+        public FilterContext OnOrAfter(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.OnOrAfter);
+        public FilterContext LastYear(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.LastYear);
+        public FilterContext ThisYear(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.ThisYear);
+        public FilterContext NextYear(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.NextYear);
+        public FilterContext LastXHours(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.LastXHours);
+        public FilterContext NextXHours(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NextXHours);
+        public FilterContext LastXDays(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.LastXDays);
+        public FilterContext NextXDays(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NextXDays);
+        public FilterContext LastXWeeks(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.LastXWeeks);
+        public FilterContext NextXWeeks(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NextXWeeks);
+        public FilterContext LastXMonths(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.LastXMonths);
+        public FilterContext NextXMonths(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NextXMonths);
+        public FilterContext LastXYears(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.LastXYears);
+        public FilterContext NextXYears(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NextXYears);
+        public FilterContext EqualUserId(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.EqualUserId);
+        public FilterContext NotEqualUserId(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NotEqualUserId);
+        public FilterContext EqualBusinessId(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.EqualBusinessId);
+        public FilterContext NotEqualBusinessId(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NotEqualBusinessId);
+        public FilterContext ChildOf(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.ChildOf);
+        public FilterContext Mask(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.Mask);
+        public FilterContext NotMask(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NotMask);
+        public FilterContext MasksSelect(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.MasksSelect);
+        public FilterContext Contains(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.Contains);
+        public FilterContext DoesNotContain(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.DoesNotContain);
+        public FilterContext EqualUserLanguage(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.EqualUserLanguage);
+        public FilterContext NotOn(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NotOn);
+        public FilterContext OlderThanXMonths(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.OlderThanXMonths);
+        public FilterContext BeginsWith(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.BeginsWith);
+        public FilterContext DoesNotBeginWith(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.DoesNotBeginWith);
+        public FilterContext EndsWith(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.EndsWith);
+        public FilterContext DoesNotEndWith(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.DoesNotEndWith);
+        public FilterContext ThisFiscalYear(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.ThisFiscalYear);
+        public FilterContext ThisFiscalPeriod(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.ThisFiscalPeriod);
+        public FilterContext NextFiscalYear(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.NextFiscalYear);
+        public FilterContext NextFiscalPeriod(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.NextFiscalPeriod);
+        public FilterContext LastFiscalYear(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.LastFiscalYear);
+        public FilterContext LastFiscalPeriod(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.LastFiscalPeriod);
+        public FilterContext LastXFiscalYears(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.LastXFiscalYears);
+        public FilterContext LastXFiscalPeriods(string columnName, object value = null) => HandleInternal(columnName, value, ConditionOperator.LastXFiscalPeriods);
+        public FilterContext NextXFiscalYears(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NextXFiscalYears);
+        public FilterContext NextXFiscalPeriods(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NextXFiscalPeriods);
+        public FilterContext InFiscalYear(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.InFiscalYear);
+        public FilterContext InFiscalPeriod(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.InFiscalPeriod);
+        public FilterContext InFiscalPeriodAndYear(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.InFiscalPeriodAndYear);
+        public FilterContext InOrBeforeFiscalPeriodAndYear(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.InOrBeforeFiscalPeriodAndYear);
+        public FilterContext InOrAfterFiscalPeriodAndYear(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.InOrAfterFiscalPeriodAndYear);
+        public FilterContext EqualUserTeams(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.EqualUserTeams);
+        public FilterContext EqualUserOrUserTeams(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.EqualUserOrUserTeams);
+        public FilterContext Under(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.Under);
+        public FilterContext NotUnder(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.NotUnder);
+        public FilterContext UnderOrEqual(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.UnderOrEqual);
+        public FilterContext Above(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.Above);
+        public FilterContext AboveOrEqual(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.AboveOrEqual);
+        public FilterContext EqualUserOrUserHierarchy(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.EqualUserOrUserHierarchy);
+        public FilterContext EqualUserOrUserHierarchyAndTeams(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.EqualUserOrUserHierarchyAndTeams);
+        public FilterContext OlderThanXYears(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.OlderThanXYears);
+        public FilterContext OlderThanXWeeks(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.OlderThanXWeeks);
+        public FilterContext OlderThanXDays(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.OlderThanXDays);
+        public FilterContext OlderThanXHours(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.OlderThanXHours);
+        public FilterContext OlderThanXMinutes(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.OlderThanXMinutes);
+        public FilterContext ContainValues(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.ContainValues);
+        public FilterContext DoesNotContainValues(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.DoesNotContainValues);
+        public FilterContext EqualRoleBusinessId(string columnName, object value) => HandleInternal(columnName, value, ConditionOperator.EqualRoleBusinessId);
 
         #endregion
 
-        internal FilterContext Conditions(LogicalOperator logicalOperator, Action<FilterContext> configureFilter)
+        public FilterContext Conditions(LogicalOperator logicalOperator, Action<FilterContext> configureFilter)
         {
             var filterExpression = new FilterExpression(logicalOperator);
             var filterContext = new FilterContext(filterExpression);
@@ -145,7 +145,7 @@ namespace DataversePluginTemplate.Queries
     /// <seealso cref="QueryContext{T}"/>.
     /// </summary>
     /// <typeparam name="T">The type of entity to query.</typeparam>
-    internal sealed class FilterContext<T>
+    public sealed class FilterContext<T>
         where T : BaseEntity<T>
     {
         private readonly FilterExpression _filterExpression;
@@ -157,100 +157,100 @@ namespace DataversePluginTemplate.Queries
 
         #region - Methoden für Condtions -
 
-        internal FilterContext<T> Equals<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.Equal);
-        internal FilterContext<T> NotEqual<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NotEqual);
-        internal FilterContext<T> Greater<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.GreaterThan);
-        internal FilterContext<T> LessThan<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.LessThan);
-        internal FilterContext<T> GreaterEqual<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.GreaterEqual);
-        internal FilterContext<T> LessEqual<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.LessEqual);
-        internal FilterContext<T> Like<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.Like);
-        internal FilterContext<T> NotLike<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NotLike);
-        internal FilterContext<T> In<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.In);
-        internal FilterContext<T> NotIn<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NotIn);
-        internal FilterContext<T> Between<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.Between);
-        internal FilterContext<T> NotBetween<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NotBetween);
-        internal FilterContext<T> IsNull<TProperty>(Expression<Func<TProperty>> propertySelector) => HandleInternal(propertySelector, ConditionOperator.Null);
-        internal FilterContext<T> IsNotNull<TProperty>(Expression<Func<TProperty>> propertySelector) => HandleInternal(propertySelector, ConditionOperator.NotNull);
-        internal FilterContext<T> Yesterday<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.Yesterday);
-        internal FilterContext<T> Today<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.Today);
-        internal FilterContext<T> Tomorrow<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.Tomorrow);
-        internal FilterContext<T> Last7Days<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.Last7Days);
-        internal FilterContext<T> Next7Days<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.Next7Days);
-        internal FilterContext<T> LastWeek<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.LastWeek);
-        internal FilterContext<T> ThisWeek<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.ThisWeek);
-        internal FilterContext<T> NextWeek<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.NextWeek);
-        internal FilterContext<T> LastMonth<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.LastMonth);
-        internal FilterContext<T> ThisMonth<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.ThisMonth);
-        internal FilterContext<T> NextMonth<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.NextMonth);
-        internal FilterContext<T> On<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.On);
-        internal FilterContext<T> OnOrBefore<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.OnOrBefore);
-        internal FilterContext<T> OnOrAfter<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.OnOrAfter);
-        internal FilterContext<T> LastYear<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.LastYear);
-        internal FilterContext<T> ThisYear<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.ThisYear);
-        internal FilterContext<T> NextYear<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.NextYear);
-        internal FilterContext<T> LastXHours<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.LastXHours);
-        internal FilterContext<T> NextXHours<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NextXHours);
-        internal FilterContext<T> LastXDays<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.LastXDays);
-        internal FilterContext<T> NextXDays<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NextXDays);
-        internal FilterContext<T> LastXWeeks<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.LastXWeeks);
-        internal FilterContext<T> NextXWeeks<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NextXWeeks);
-        internal FilterContext<T> LastXMonths<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.LastXMonths);
-        internal FilterContext<T> NextXMonths<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NextXMonths);
-        internal FilterContext<T> LastXYears<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.LastXYears);
-        internal FilterContext<T> NextXYears<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NextXYears);
-        internal FilterContext<T> EqualUserId<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.EqualUserId);
-        internal FilterContext<T> NotEqualUserId<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NotEqualUserId);
-        internal FilterContext<T> EqualBusinessId<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.EqualBusinessId);
-        internal FilterContext<T> NotEqualBusinessId<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NotEqualBusinessId);
-        internal FilterContext<T> ChildOf<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.ChildOf);
-        internal FilterContext<T> Mask<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.Mask);
-        internal FilterContext<T> NotMask<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NotMask);
-        internal FilterContext<T> MasksSelect<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.MasksSelect);
-        internal FilterContext<T> Contains<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.Contains);
-        internal FilterContext<T> DoesNotContain<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.DoesNotContain);
-        internal FilterContext<T> EqualUserLanguage<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.EqualUserLanguage);
-        internal FilterContext<T> NotOn<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NotOn);
-        internal FilterContext<T> OlderThanXMonths<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.OlderThanXMonths);
-        internal FilterContext<T> BeginsWith<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.BeginsWith);
-        internal FilterContext<T> DoesNotBeginWith<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.DoesNotBeginWith);
-        internal FilterContext<T> EndsWith<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.EndsWith);
-        internal FilterContext<T> DoesNotEndWith<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.DoesNotEndWith);
-        internal FilterContext<T> ThisFiscalYear<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.ThisFiscalYear);
-        internal FilterContext<T> ThisFiscalPeriod<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.ThisFiscalPeriod);
-        internal FilterContext<T> NextFiscalYear<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.NextFiscalYear);
-        internal FilterContext<T> NextFiscalPeriod<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.NextFiscalPeriod);
-        internal FilterContext<T> LastFiscalYear<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.LastFiscalYear);
-        internal FilterContext<T> LastFiscalPeriod<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.LastFiscalPeriod);
-        internal FilterContext<T> LastXFiscalYears<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.LastXFiscalYears);
-        internal FilterContext<T> LastXFiscalPeriods<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.LastXFiscalPeriods);
-        internal FilterContext<T> NextXFiscalYears<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NextXFiscalYears);
-        internal FilterContext<T> NextXFiscalPeriods<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NextXFiscalPeriods);
-        internal FilterContext<T> InFiscalYear<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.InFiscalYear);
-        internal FilterContext<T> InFiscalPeriod<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.InFiscalPeriod);
-        internal FilterContext<T> InFiscalPeriodAndYear<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.InFiscalPeriodAndYear);
-        internal FilterContext<T> InOrBeforeFiscalPeriodAndYear<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.InOrBeforeFiscalPeriodAndYear);
-        internal FilterContext<T> InOrAfterFiscalPeriodAndYear<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.InOrAfterFiscalPeriodAndYear);
-        internal FilterContext<T> EqualUserTeams<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.EqualUserTeams);
-        internal FilterContext<T> EqualUserOrUserTeams<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.EqualUserOrUserTeams);
-        internal FilterContext<T> Under<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.Under);
-        internal FilterContext<T> NotUnder<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NotUnder);
-        internal FilterContext<T> UnderOrEqual<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.UnderOrEqual);
-        internal FilterContext<T> Above<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.Above);
-        internal FilterContext<T> AboveOrEqual<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.AboveOrEqual);
-        internal FilterContext<T> EqualUserOrUserHierarchy<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.EqualUserOrUserHierarchy);
-        internal FilterContext<T> EqualUserOrUserHierarchyAndTeams<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.EqualUserOrUserHierarchyAndTeams);
-        internal FilterContext<T> OlderThanXYears<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.OlderThanXYears);
-        internal FilterContext<T> OlderThanXWeeks<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.OlderThanXWeeks);
-        internal FilterContext<T> OlderThanXDays<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.OlderThanXDays);
-        internal FilterContext<T> OlderThanXHours<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.OlderThanXHours);
-        internal FilterContext<T> OlderThanXMinutes<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.OlderThanXMinutes);
-        internal FilterContext<T> ContainValues<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.ContainValues);
-        internal FilterContext<T> DoesNotContainValues<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.DoesNotContainValues);
-        internal FilterContext<T> EqualRoleBusinessId<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.EqualRoleBusinessId);
+        public FilterContext<T> Equals<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.Equal);
+        public FilterContext<T> NotEqual<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NotEqual);
+        public FilterContext<T> Greater<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.GreaterThan);
+        public FilterContext<T> LessThan<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.LessThan);
+        public FilterContext<T> GreaterEqual<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.GreaterEqual);
+        public FilterContext<T> LessEqual<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.LessEqual);
+        public FilterContext<T> Like<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.Like);
+        public FilterContext<T> NotLike<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NotLike);
+        public FilterContext<T> In<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.In);
+        public FilterContext<T> NotIn<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NotIn);
+        public FilterContext<T> Between<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.Between);
+        public FilterContext<T> NotBetween<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NotBetween);
+        public FilterContext<T> IsNull<TProperty>(Expression<Func<TProperty>> propertySelector) => HandleInternal(propertySelector, ConditionOperator.Null);
+        public FilterContext<T> IsNotNull<TProperty>(Expression<Func<TProperty>> propertySelector) => HandleInternal(propertySelector, ConditionOperator.NotNull);
+        public FilterContext<T> Yesterday<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.Yesterday);
+        public FilterContext<T> Today<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.Today);
+        public FilterContext<T> Tomorrow<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.Tomorrow);
+        public FilterContext<T> Last7Days<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.Last7Days);
+        public FilterContext<T> Next7Days<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.Next7Days);
+        public FilterContext<T> LastWeek<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.LastWeek);
+        public FilterContext<T> ThisWeek<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.ThisWeek);
+        public FilterContext<T> NextWeek<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.NextWeek);
+        public FilterContext<T> LastMonth<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.LastMonth);
+        public FilterContext<T> ThisMonth<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.ThisMonth);
+        public FilterContext<T> NextMonth<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.NextMonth);
+        public FilterContext<T> On<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.On);
+        public FilterContext<T> OnOrBefore<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.OnOrBefore);
+        public FilterContext<T> OnOrAfter<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.OnOrAfter);
+        public FilterContext<T> LastYear<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.LastYear);
+        public FilterContext<T> ThisYear<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.ThisYear);
+        public FilterContext<T> NextYear<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.NextYear);
+        public FilterContext<T> LastXHours<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.LastXHours);
+        public FilterContext<T> NextXHours<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NextXHours);
+        public FilterContext<T> LastXDays<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.LastXDays);
+        public FilterContext<T> NextXDays<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NextXDays);
+        public FilterContext<T> LastXWeeks<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.LastXWeeks);
+        public FilterContext<T> NextXWeeks<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NextXWeeks);
+        public FilterContext<T> LastXMonths<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.LastXMonths);
+        public FilterContext<T> NextXMonths<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NextXMonths);
+        public FilterContext<T> LastXYears<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.LastXYears);
+        public FilterContext<T> NextXYears<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NextXYears);
+        public FilterContext<T> EqualUserId<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.EqualUserId);
+        public FilterContext<T> NotEqualUserId<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NotEqualUserId);
+        public FilterContext<T> EqualBusinessId<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.EqualBusinessId);
+        public FilterContext<T> NotEqualBusinessId<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NotEqualBusinessId);
+        public FilterContext<T> ChildOf<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.ChildOf);
+        public FilterContext<T> Mask<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.Mask);
+        public FilterContext<T> NotMask<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NotMask);
+        public FilterContext<T> MasksSelect<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.MasksSelect);
+        public FilterContext<T> Contains<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.Contains);
+        public FilterContext<T> DoesNotContain<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.DoesNotContain);
+        public FilterContext<T> EqualUserLanguage<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.EqualUserLanguage);
+        public FilterContext<T> NotOn<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NotOn);
+        public FilterContext<T> OlderThanXMonths<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.OlderThanXMonths);
+        public FilterContext<T> BeginsWith<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.BeginsWith);
+        public FilterContext<T> DoesNotBeginWith<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.DoesNotBeginWith);
+        public FilterContext<T> EndsWith<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.EndsWith);
+        public FilterContext<T> DoesNotEndWith<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.DoesNotEndWith);
+        public FilterContext<T> ThisFiscalYear<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.ThisFiscalYear);
+        public FilterContext<T> ThisFiscalPeriod<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.ThisFiscalPeriod);
+        public FilterContext<T> NextFiscalYear<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.NextFiscalYear);
+        public FilterContext<T> NextFiscalPeriod<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.NextFiscalPeriod);
+        public FilterContext<T> LastFiscalYear<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.LastFiscalYear);
+        public FilterContext<T> LastFiscalPeriod<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.LastFiscalPeriod);
+        public FilterContext<T> LastXFiscalYears<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.LastXFiscalYears);
+        public FilterContext<T> LastXFiscalPeriods<TProperty>(Expression<Func<TProperty>> propertySelector, object value = null) => HandleInternal(propertySelector, value, ConditionOperator.LastXFiscalPeriods);
+        public FilterContext<T> NextXFiscalYears<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NextXFiscalYears);
+        public FilterContext<T> NextXFiscalPeriods<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NextXFiscalPeriods);
+        public FilterContext<T> InFiscalYear<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.InFiscalYear);
+        public FilterContext<T> InFiscalPeriod<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.InFiscalPeriod);
+        public FilterContext<T> InFiscalPeriodAndYear<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.InFiscalPeriodAndYear);
+        public FilterContext<T> InOrBeforeFiscalPeriodAndYear<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.InOrBeforeFiscalPeriodAndYear);
+        public FilterContext<T> InOrAfterFiscalPeriodAndYear<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.InOrAfterFiscalPeriodAndYear);
+        public FilterContext<T> EqualUserTeams<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.EqualUserTeams);
+        public FilterContext<T> EqualUserOrUserTeams<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.EqualUserOrUserTeams);
+        public FilterContext<T> Under<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.Under);
+        public FilterContext<T> NotUnder<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.NotUnder);
+        public FilterContext<T> UnderOrEqual<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.UnderOrEqual);
+        public FilterContext<T> Above<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.Above);
+        public FilterContext<T> AboveOrEqual<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.AboveOrEqual);
+        public FilterContext<T> EqualUserOrUserHierarchy<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.EqualUserOrUserHierarchy);
+        public FilterContext<T> EqualUserOrUserHierarchyAndTeams<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.EqualUserOrUserHierarchyAndTeams);
+        public FilterContext<T> OlderThanXYears<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.OlderThanXYears);
+        public FilterContext<T> OlderThanXWeeks<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.OlderThanXWeeks);
+        public FilterContext<T> OlderThanXDays<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.OlderThanXDays);
+        public FilterContext<T> OlderThanXHours<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.OlderThanXHours);
+        public FilterContext<T> OlderThanXMinutes<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.OlderThanXMinutes);
+        public FilterContext<T> ContainValues<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.ContainValues);
+        public FilterContext<T> DoesNotContainValues<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.DoesNotContainValues);
+        public FilterContext<T> EqualRoleBusinessId<TProperty>(Expression<Func<TProperty>> propertySelector, object value) => HandleInternal(propertySelector, value, ConditionOperator.EqualRoleBusinessId);
 
         #endregion
 
-        internal FilterContext<T> Conditions(LogicalOperator logicalOperator, Action<FilterContext<T>> configureFilter)
+        public FilterContext<T> Conditions(LogicalOperator logicalOperator, Action<FilterContext<T>> configureFilter)
         {
             var filterExpression = new FilterExpression(logicalOperator);
             var filterContext = new FilterContext<T>(filterExpression);
@@ -270,6 +270,7 @@ namespace DataversePluginTemplate.Queries
             _filterExpression.Conditions.Add(condition);
             return this;
         }
+
         private FilterContext<T> HandleInternal<TProperty>(Expression<Func<TProperty>> propertySelector, object value, ConditionOperator conditionOperator)
         {
             var propertyInfo = ExpressionExtensionMethods.GetPropertyInfo<T, TProperty>(propertySelector);

--- a/DataversePluginTemplate/Queries/IncludeContext.cs
+++ b/DataversePluginTemplate/Queries/IncludeContext.cs
@@ -13,28 +13,28 @@ namespace DataversePluginTemplate.Queries
     /// </summary>
     /// <typeparam name="TInner">The type of entity used as inner part of the join.</typeparam>
     /// <typeparam name="TOuter">The type of entity used as outer part of the join.</typeparam>
-    internal class IncludeContext<TInner, TOuter>
+    public sealed class IncludeContext<TInner, TOuter>
         where TInner : BaseEntity<TInner>
         where TOuter : BaseEntity<TOuter>
     {
         private readonly LinkEntity _linkEntity;
         private readonly IncludeEntity _includeEntity;
 
-        public IncludeContext(LinkEntity linkEntity, IncludeEntity includeEntity)
+        internal IncludeContext(LinkEntity linkEntity, IncludeEntity includeEntity)
         {
             _linkEntity = linkEntity;
             _includeEntity = includeEntity;
             _linkEntity.EntityAlias = includeEntity.EntityLogicalName;
         }
 
-        internal IncludeContext<TInner, TOuter> Alias(string entityAlias)
+        public IncludeContext<TInner, TOuter> Alias(string entityAlias)
         {
             _linkEntity.EntityAlias = entityAlias;
             _includeEntity.EntityAlias = entityAlias;
             return this;
         }
 
-        internal IncludeContext<TInner, TOuter> Columns(Expression<Func<TOuter, object[]>> propertySelector)
+        public IncludeContext<TInner, TOuter> Columns(Expression<Func<TOuter, object[]>> propertySelector)
         {
             var propertyInfos = propertySelector.GetPropertyInfos();
 
@@ -46,7 +46,7 @@ namespace DataversePluginTemplate.Queries
             return this;
         }
 
-        internal IncludeContext<TInner, TOuter> Columns(Columns columns)
+        public IncludeContext<TInner, TOuter> Columns(Columns columns)
         {
             switch (columns)
             {
@@ -63,13 +63,13 @@ namespace DataversePluginTemplate.Queries
             return this;
         }
 
-        internal IncludeContext<TInner, TOuter> AllDefinedColumns()
+        public IncludeContext<TInner, TOuter> AllDefinedColumns()
         {
             _linkEntity.Columns.AddColumns(typeof(TOuter).GetAllDefinedLogicalNames());
             return this;
         }
 
-        internal IncludeContext<TInner, TOuter> Conditions(LogicalOperator logicalOperator, Action<FilterContext<TOuter>, TOuter> configureFilter)
+        public IncludeContext<TInner, TOuter> Conditions(LogicalOperator logicalOperator, Action<FilterContext<TOuter>, TOuter> configureFilter)
         {
             var filterExpression = new FilterExpression(logicalOperator);
 
@@ -80,19 +80,19 @@ namespace DataversePluginTemplate.Queries
 
             return this;
         }
-        internal IncludeContext<TInner, TOuter> AllColumns(bool allColumns = true)
+        public IncludeContext<TInner, TOuter> AllColumns(bool allColumns = true)
         {
             _linkEntity.Columns.AllColumns = allColumns;
             return this;
         }
 
-        internal IncludeContext<TInner, TOuter> ThenInclude<T>(Expression<Func<TOuter, T>> includePropertySelector, Action<IncludeContext<TOuter, T>> configureLink)
+        public IncludeContext<TInner, TOuter> ThenInclude<T>(Expression<Func<TOuter, T>> includePropertySelector, Action<IncludeContext<TOuter, T>> configureLink)
             where T : BaseEntity<T>
         {
             return ThenInclude<T>(includePropertySelector, JoinOperator.LeftOuter, configureLink);
         }
 
-        internal IncludeContext<TInner, TOuter> ThenInclude<T>(Expression<Func<TOuter, T>> includePropertySelector, JoinOperator joinOperator, Action<IncludeContext<TOuter, T>> configureLink)
+        public IncludeContext<TInner, TOuter> ThenInclude<T>(Expression<Func<TOuter, T>> includePropertySelector, JoinOperator joinOperator, Action<IncludeContext<TOuter, T>> configureLink)
             where T : BaseEntity<T>
         {
             var entityName = typeof(T).GetLogicalName();

--- a/DataversePluginTemplate/Queries/LinkContext.cs
+++ b/DataversePluginTemplate/Queries/LinkContext.cs
@@ -11,7 +11,7 @@ namespace DataversePluginTemplate.Queries
     /// <summary>
     /// Wrapper for joining entities in <see cref="QueryContext"/>.
     /// </summary>
-    internal sealed class LinkContext
+    public sealed class LinkContext
     {
         private readonly LinkEntity _linkEntity;
         private readonly string _entityName;
@@ -22,19 +22,19 @@ namespace DataversePluginTemplate.Queries
             _linkEntity = linkEntity;
         }
 
-        internal LinkContext Alias(string alias)
+        public LinkContext Alias(string alias)
         {
             _linkEntity.EntityAlias = alias;
             return this;
         }
 
-        internal LinkContext Columns(params string[] columns)
+        public LinkContext Columns(params string[] columns)
         {
             _linkEntity.Columns.AddColumns(columns);
             return this;
         }
 
-        internal LinkContext Columns(IEnumerable<string> columns)
+        public LinkContext Columns(IEnumerable<string> columns)
         {
             foreach (var column in columns)
                 _linkEntity.Columns.AddColumn(column);
@@ -42,13 +42,13 @@ namespace DataversePluginTemplate.Queries
             return this;
         }
 
-        internal LinkContext AllColumns(bool allColumns = true)
+        public LinkContext AllColumns(bool allColumns = true)
         {
             _linkEntity.Columns.AllColumns = allColumns;
             return this;
         }
 
-        internal LinkContext Conditions(LogicalOperator logicalOperator, Action<FilterContext> configureFilter)
+        public LinkContext Conditions(LogicalOperator logicalOperator, Action<FilterContext> configureFilter)
         {
             var filterExpression = new FilterExpression(logicalOperator);
 
@@ -60,12 +60,12 @@ namespace DataversePluginTemplate.Queries
             return this;
         }
 
-        internal LinkContext Join(string entityName, string fromColumn, string toColumn, Action<LinkContext> configureLink)
+        public LinkContext Join(string entityName, string fromColumn, string toColumn, Action<LinkContext> configureLink)
         {
             return Join(entityName, fromColumn, toColumn, JoinOperator.Inner, configureLink);
         }
 
-        internal LinkContext Join(string entityName, string fromColumn, string toColumn, JoinOperator joinOperator, Action<LinkContext> configureLink)
+        public LinkContext Join(string entityName, string fromColumn, string toColumn, JoinOperator joinOperator, Action<LinkContext> configureLink)
         {
             var linkEntity = new LinkEntity(_entityName, entityName, fromColumn, toColumn, joinOperator);
             var linkContext = new LinkContext(linkEntity, entityName);
@@ -81,7 +81,7 @@ namespace DataversePluginTemplate.Queries
     /// </summary>
     /// <typeparam name="TInner">The type of entity used as inner part of the join.</typeparam>
     /// <typeparam name="TOuter">The type of entity used as outer part of the join.</typeparam>
-    internal sealed class LinkContext<TInner, TOuter>
+    public sealed class LinkContext<TInner, TOuter>
         where TInner : BaseEntity<TInner>
         where TOuter : BaseEntity<TOuter>
     {
@@ -94,13 +94,13 @@ namespace DataversePluginTemplate.Queries
             _linkEntity = linkEntity;
         }
 
-        internal LinkContext<TInner, TOuter> Alias(string alias)
+        public LinkContext<TInner, TOuter> Alias(string alias)
         {
             _linkEntity.EntityAlias = alias;
             return this;
         }
 
-        internal LinkContext<TInner, TOuter> Columns(Expression<Func<TOuter, object[]>> propertySelector)
+        public LinkContext<TInner, TOuter> Columns(Expression<Func<TOuter, object[]>> propertySelector)
         {
             var propertyInfos = propertySelector.GetPropertyInfos();
 
@@ -112,7 +112,7 @@ namespace DataversePluginTemplate.Queries
             return this;
         }
 
-        internal LinkContext<TInner, TOuter> Columns(Columns columns)
+        public LinkContext<TInner, TOuter> Columns(Columns columns)
         {
             switch (columns)
             {
@@ -129,13 +129,13 @@ namespace DataversePluginTemplate.Queries
             return this;
         }
 
-        internal LinkContext<TInner, TOuter> AllDefinedColumns()
+        public LinkContext<TInner, TOuter> AllDefinedColumns()
         {
             _linkEntity.Columns.AddColumns(typeof(TOuter).GetAllDefinedLogicalNames());
             return this;
         }
 
-        internal LinkContext<TInner, TOuter> Conditions(LogicalOperator logicalOperator, Action<FilterContext<TOuter>, TOuter> configureFilter)
+        public LinkContext<TInner, TOuter> Conditions(LogicalOperator logicalOperator, Action<FilterContext<TOuter>, TOuter> configureFilter)
         {
             var filterExpression = new FilterExpression(logicalOperator);
 
@@ -147,19 +147,19 @@ namespace DataversePluginTemplate.Queries
             return this;
         }
 
-        internal LinkContext<TInner, TOuter> AllColumns(bool allColumns = true)
+        public LinkContext<TInner, TOuter> AllColumns(bool allColumns = true)
         {
             _linkEntity.Columns.AllColumns = allColumns;
             return this;
         }
 
-        internal LinkContext<TInner, TOuter> Join<T>(Expression<Func<TOuter, object>> fromColumnSelector, Expression<Func<T, object>> toColumnSelector, Action<LinkContext<T, TOuter>> configureLink)
+        public LinkContext<TInner, TOuter> Join<T>(Expression<Func<TOuter, object>> fromColumnSelector, Expression<Func<T, object>> toColumnSelector, Action<LinkContext<T, TOuter>> configureLink)
             where T : BaseEntity<T>
         {
             return Join(fromColumnSelector, toColumnSelector, JoinOperator.Inner, configureLink);
         }
 
-        internal LinkContext<TInner, TOuter> Join<T>(Expression<Func<TOuter, object>> fromColumnSelector, Expression<Func<T, object>> toColumnSelector, JoinOperator joinOperator, Action<LinkContext<T, TOuter>> configureLink)
+        public LinkContext<TInner, TOuter> Join<T>(Expression<Func<TOuter, object>> fromColumnSelector, Expression<Func<T, object>> toColumnSelector, JoinOperator joinOperator, Action<LinkContext<T, TOuter>> configureLink)
             where T : BaseEntity<T>
         {
             var entityName = typeof(T).GetLogicalName();
@@ -173,13 +173,13 @@ namespace DataversePluginTemplate.Queries
             return this;
         }
 
-        internal LinkContext<TInner, TOuter> Join<T>(Expression<Func<T, object>> toColumnSelector, Action<LinkContext<T, TOuter>> configureLink)
+        public LinkContext<TInner, TOuter> Join<T>(Expression<Func<T, object>> toColumnSelector, Action<LinkContext<T, TOuter>> configureLink)
             where T : BaseEntity<T>
         {
             return Join(toColumnSelector, JoinOperator.Inner, configureLink);
         }
 
-        internal LinkContext<TInner, TOuter> Join<T>(Expression<Func<T, object>> toColumnSelector, JoinOperator joinOperator, Action<LinkContext<T, TOuter>> configureLink)
+        public LinkContext<TInner, TOuter> Join<T>(Expression<Func<T, object>> toColumnSelector, JoinOperator joinOperator, Action<LinkContext<T, TOuter>> configureLink)
             where T : BaseEntity<T>
         {
             var entityName = typeof(T).GetLogicalName();

--- a/DataversePluginTemplate/Queries/QueryContext.cs
+++ b/DataversePluginTemplate/Queries/QueryContext.cs
@@ -13,12 +13,12 @@ namespace DataversePluginTemplate.Queries
     /// <summary>
     /// Wrapper for building dataverse queries and retrieve entites from dataverse.
     /// </summary>
-    internal sealed class QueryContext
+    public sealed class QueryContext
     {
         private readonly IOrganizationService _orgService;
         private readonly QueryExpression _expression;
 
-        internal QueryContext(IOrganizationService orgService, string entityName)
+        public QueryContext(IOrganizationService orgService, string entityName)
         {
             _orgService = orgService;
             _expression = new QueryExpression(entityName)
@@ -28,13 +28,13 @@ namespace DataversePluginTemplate.Queries
             };
         }
 
-        internal QueryContext Columns(params string[] columns)
+        public QueryContext Columns(params string[] columns)
         {
             _expression.ColumnSet.AddColumns(columns);
             return this;
         }
 
-        internal QueryContext Columns(IEnumerable<string> columns)
+        public QueryContext Columns(IEnumerable<string> columns)
         {
             foreach (var column in columns)
                 _expression.ColumnSet.AddColumn(column);
@@ -42,25 +42,25 @@ namespace DataversePluginTemplate.Queries
             return this;
         }
 
-        internal QueryContext AllColumns(bool allColumns = true)
+        public QueryContext AllColumns(bool allColumns = true)
         {
             _expression.ColumnSet.AllColumns = allColumns;
             return this;
         }
 
-        internal QueryContext NoColumns()
+        public QueryContext NoColumns()
         {
             _expression.ColumnSet.AllColumns = false;
             return this;
         }
 
-        internal QueryContext Top(int count)
+        public QueryContext Top(int count)
         {
             _expression.TopCount = count;
             return this;
         }
 
-        internal QueryContext Conditions(LogicalOperator logicalOperator, Action<FilterContext> configureFilter)
+        public QueryContext Conditions(LogicalOperator logicalOperator, Action<FilterContext> configureFilter)
         {
             var filterExpression = new FilterExpression(logicalOperator);
 
@@ -71,12 +71,12 @@ namespace DataversePluginTemplate.Queries
             return this;
         }
 
-        internal QueryContext Join(string entityName, string fromColumn, string toColumn, Action<LinkContext> configureLink)
+        public QueryContext Join(string entityName, string fromColumn, string toColumn, Action<LinkContext> configureLink)
         {
             return Join(entityName, fromColumn, toColumn, JoinOperator.Inner, configureLink);
         }
 
-        internal QueryContext Join(string entityName, string fromColumn, string toColumn, JoinOperator joinOperator, Action<LinkContext> configureLink)
+        public QueryContext Join(string entityName, string fromColumn, string toColumn, JoinOperator joinOperator, Action<LinkContext> configureLink)
         {
             var linkEntity = new LinkEntity(_expression.EntityName, entityName, fromColumn, toColumn, joinOperator);
             var linkContext = new LinkContext(linkEntity, entityName);
@@ -85,7 +85,7 @@ namespace DataversePluginTemplate.Queries
             return this;
         }
 
-        internal EntityCollection Execute()
+        public EntityCollection Execute()
         {
             return _orgService.RetrieveMultiple(_expression);
         }
@@ -99,20 +99,20 @@ namespace DataversePluginTemplate.Queries
     /// Entities, that are queried, mus have a <see cref="LogicalNameAttribute"/>.
     /// </summary>
     /// <typeparam name="T">The qeruy result type.</typeparam>
-    internal sealed class QueryContext<T>
+    public sealed class QueryContext<T>
         where T : BaseEntity<T>
     {
         private readonly IOrganizationService _orgService;
         private readonly QueryExpression _expression;
         private readonly List<IncludeEntity> _includes = new List<IncludeEntity>();
 
-        internal QueryContext(IOrganizationService orgService)
+        public QueryContext(IOrganizationService orgService)
         {
             _orgService = orgService;
             _expression = new QueryExpression(typeof(T).GetLogicalName());
         }
 
-        internal QueryContext<T> Columns(Expression<Func<T, object[]>> propertySelector)
+        public QueryContext<T> Columns(Expression<Func<T, object[]>> propertySelector)
         {
             var propertyInfos = propertySelector.GetPropertyInfos();
 
@@ -124,7 +124,7 @@ namespace DataversePluginTemplate.Queries
             return this;
         }
 
-        internal QueryContext<T> Columns(Columns columns)
+        public QueryContext<T> Columns(Columns columns)
         {
             switch (columns)
             {
@@ -141,31 +141,31 @@ namespace DataversePluginTemplate.Queries
             return this;
         }
 
-        internal QueryContext<T> AllDefinedColumns()
+        public QueryContext<T> AllDefinedColumns()
         {
             _expression.ColumnSet.AddColumns(typeof(T).GetAllDefinedLogicalNames());
             return this;
         }
 
-        internal QueryContext<T> AllColumns(bool allColumns = true)
+        public QueryContext<T> AllColumns(bool allColumns = true)
         {
             _expression.ColumnSet.AllColumns = allColumns;
             return this;
         }
 
-        internal QueryContext<T> NoColumns()
+        public QueryContext<T> NoColumns()
         {
             _expression.ColumnSet.AllColumns = false;
             return this;
         }
 
-        internal QueryContext<T> Top(int count)
+        public QueryContext<T> Top(int count)
         {
             _expression.TopCount = count;
             return this;
         }
 
-        internal QueryContext<T> Conditions(LogicalOperator logicalOperator, Action<FilterContext<T>, T> configureFilter)
+        public QueryContext<T> Conditions(LogicalOperator logicalOperator, Action<FilterContext<T>, T> configureFilter)
         {
             var filterExpression = new FilterExpression(logicalOperator);
 
@@ -176,13 +176,13 @@ namespace DataversePluginTemplate.Queries
             return this;
         }
 
-        internal QueryContext<T> Join<TOuter>(Expression<Func<T, object>> fromColumnSelector, Expression<Func<TOuter, object>> toColumnSelector, Action<LinkContext<T, TOuter>> configureLink)
+        public QueryContext<T> Join<TOuter>(Expression<Func<T, object>> fromColumnSelector, Expression<Func<TOuter, object>> toColumnSelector, Action<LinkContext<T, TOuter>> configureLink)
             where TOuter : BaseEntity<TOuter>
         {
             return Join(fromColumnSelector, toColumnSelector, JoinOperator.Inner, configureLink);
         }
 
-        internal QueryContext<T> Join<TOuter>(Expression<Func<T, object>> fromColumnSelector, Expression<Func<TOuter, object>> toColumnSelector, JoinOperator joinOperator, Action<LinkContext<T, TOuter>> configureLink)
+        public QueryContext<T> Join<TOuter>(Expression<Func<T, object>> fromColumnSelector, Expression<Func<TOuter, object>> toColumnSelector, JoinOperator joinOperator, Action<LinkContext<T, TOuter>> configureLink)
             where TOuter : BaseEntity<TOuter>
         {
             var entityName = typeof(TOuter).GetLogicalName();
@@ -196,13 +196,13 @@ namespace DataversePluginTemplate.Queries
             return this;
         }
 
-        internal QueryContext<T> Join<TOuter>(Expression<Func<TOuter, object>> toColumnSelector, Action<LinkContext<T, TOuter>> configureLink)
+        public QueryContext<T> Join<TOuter>(Expression<Func<TOuter, object>> toColumnSelector, Action<LinkContext<T, TOuter>> configureLink)
             where TOuter : BaseEntity<TOuter>
         {
             return Join(toColumnSelector, JoinOperator.Inner, configureLink);
         }
 
-        internal QueryContext<T> Join<TOuter>(Expression<Func<TOuter, object>> toColumnSelector, JoinOperator joinOperator, Action<LinkContext<T, TOuter>> configureLink)
+        public QueryContext<T> Join<TOuter>(Expression<Func<TOuter, object>> toColumnSelector, JoinOperator joinOperator, Action<LinkContext<T, TOuter>> configureLink)
             where TOuter : BaseEntity<TOuter>
         {
             var entityName = typeof(TOuter).GetLogicalName();
@@ -216,7 +216,7 @@ namespace DataversePluginTemplate.Queries
             return this;
         }
 
-        internal QueryContext<T> Include<TOuter>(Expression<Func<T, TOuter>> includePropertySelector, Action<IncludeContext<T, TOuter>> configureInclude)
+        public QueryContext<T> Include<TOuter>(Expression<Func<T, TOuter>> includePropertySelector, Action<IncludeContext<T, TOuter>> configureInclude)
            where TOuter : BaseEntity<TOuter>
         {
             return Include<TOuter>(includePropertySelector, JoinOperator.LeftOuter, configureInclude);
@@ -233,7 +233,7 @@ namespace DataversePluginTemplate.Queries
         /// <param name="joinOperator">How dataverse should join the data.</param>
         /// <param name="configureInclude">Configure the included entity</param>
         /// <returns>The same QueryContext for chaining.</returns>
-        internal QueryContext<T> Include<TOuter>(Expression<Func<T, TOuter>> includePropertySelector, JoinOperator joinOperator, Action<IncludeContext<T, TOuter>> configureInclude)
+        public QueryContext<T> Include<TOuter>(Expression<Func<T, TOuter>> includePropertySelector, JoinOperator joinOperator, Action<IncludeContext<T, TOuter>> configureInclude)
             where TOuter : BaseEntity<TOuter>
         {
             var entityName = typeof(TOuter).GetLogicalName();
@@ -257,7 +257,7 @@ namespace DataversePluginTemplate.Queries
         /// Makes the call to dataverse to retrieve the entities and convert them into your instances.
         /// </summary>
         /// <returns>The entites as your type.</returns>
-        internal IEnumerable<T> Execute()
+        public IEnumerable<T> Execute()
         {
             var queryResults = _orgService.RetrieveMultiple(_expression).As<T>();
 

--- a/DataversePluginTemplate/Service/API/APIException.cs
+++ b/DataversePluginTemplate/Service/API/APIException.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace DataversePluginTemplate.Service.API
 {
-    internal class APIException : Exception
+    public class APIException : Exception
     {
         public PluginHttpStatusCode StatusCode { get; set; } = PluginHttpStatusCode.InternalServerError;
 

--- a/DataversePluginTemplate/Service/API/APIParameterAttribute.cs
+++ b/DataversePluginTemplate/Service/API/APIParameterAttribute.cs
@@ -6,7 +6,7 @@ namespace DataversePluginTemplate.Service.API
     /// Used for properties of <see cref="BaseInputModel{TInput}"/> which allows mapping
     /// values of the plugins InputParameters onto the properties of the instance.
     /// </summary>
-    internal class APIParameterAttribute : Attribute
+    public class APIParameterAttribute : Attribute
     {
         public string Name { get; private set; }
         public ParameterType InputType { get; private set; }

--- a/DataversePluginTemplate/Service/API/ParameterType.cs
+++ b/DataversePluginTemplate/Service/API/ParameterType.cs
@@ -1,6 +1,6 @@
 ﻿namespace DataversePluginTemplate.Service.API
 {
-    internal enum ParameterType
+    public enum ParameterType
     {
         Guid,
         String,

--- a/DataversePluginTemplate/Service/API/RequestAttribute.cs
+++ b/DataversePluginTemplate/Service/API/RequestAttribute.cs
@@ -6,7 +6,7 @@ namespace DataversePluginTemplate.Service.API
     /// Use this to specify the dataverse Custom API message. Use on <see cref="BaseInputModel{TInput}"/>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
-    internal class RequestAttribute : Attribute
+    public class RequestAttribute : Attribute
     {
         public string Name { get; }
 

--- a/DataversePluginTemplate/Service/API/RequiredAttribute.cs
+++ b/DataversePluginTemplate/Service/API/RequiredAttribute.cs
@@ -2,5 +2,5 @@
 
 namespace DataversePluginTemplate.Service.API
 {
-    internal class RequiredAttribute : Attribute { }
+    public class RequiredAttribute : Attribute { }
 }

--- a/DataversePluginTemplate/Service/Entities/BaseEntity.cs
+++ b/DataversePluginTemplate/Service/Entities/BaseEntity.cs
@@ -23,15 +23,15 @@ namespace DataversePluginTemplate.Service.Entities
     /// This approach is required for <see cref="Queries.QueryContext{T}"/>.
     /// </summary>
     /// <typeparam name="TChild">The type of child class itself. For typesafty in child classes.</typeparam>
-    internal abstract class BaseEntity<TChild>
+    public abstract class BaseEntity<TChild>
     {
         private readonly Entity _entity;
-        internal Entity Entity => _entity;
-        internal EntityReference Reference => _entity.ToEntityReference();
+        public Entity Entity => _entity;
+        public EntityReference Reference => _entity.ToEntityReference();
 
-        internal Guid Id { get => _entity.Id; set => _entity.Id = value; }
+        public virtual Guid Id { get => _entity.Id; set => _entity.Id = value; }
 
-        internal BaseEntity(Entity entity = null)
+        protected BaseEntity(Entity entity = null)
         {
             if (entity != null)
                 _entity = entity;
@@ -39,28 +39,28 @@ namespace DataversePluginTemplate.Service.Entities
                 _entity = new Entity(typeof(TChild).GetLogicalName());
         }
 
-        public void Set<TProperty, TValue>(Expression<Func<TChild, TProperty>> propertyExpression, TValue value)
+        protected void Set<TProperty, TValue>(Expression<Func<TChild, TProperty>> propertyExpression, TValue value)
         {
             var property = propertyExpression.GetPropertyInfo();
             var logicalName = property.GetLogicalName();
             _entity.Attributes[logicalName] = value;
         }
 
-        public TProperty Get<TProperty>(Expression<Func<TChild, TProperty>> propertyExpression)
+        protected TProperty Get<TProperty>(Expression<Func<TChild, TProperty>> propertyExpression)
         {
             var property = propertyExpression.GetPropertyInfo();
             var logicalName = property.GetLogicalName();
             return _entity.GetAttributeValue<TProperty>(logicalName);
         }
 
-        public TProperty Get<TProperty, TValue>(Expression<Func<TChild, TProperty>> propertyExpression, Func<TValue, TProperty> valueSelector)
+        protected TProperty Get<TProperty, TValue>(Expression<Func<TChild, TProperty>> propertyExpression, Func<TValue, TProperty> valueSelector)
         {
             var property = propertyExpression.GetPropertyInfo();
             var logicalName = property.GetLogicalName();
             return valueSelector(_entity.GetAttributeValue<TValue>(logicalName));
         }
 
-        public TProperty? GetEnum<TProperty>(Expression<Func<TChild, TProperty?>> propertyExpression)
+        protected TProperty? GetEnum<TProperty>(Expression<Func<TChild, TProperty?>> propertyExpression)
             where TProperty : struct, Enum
         {
             var property = propertyExpression.GetPropertyInfo();
@@ -69,7 +69,7 @@ namespace DataversePluginTemplate.Service.Entities
             return value == null ? (TProperty?)null : (TProperty)Enum.ToObject(typeof(TProperty), value.Value);
         }
 
-        public void SetEnum<TProperty>(Expression<Func<TChild, TProperty?>> propertyExpression, TProperty? value)
+        protected void SetEnum<TProperty>(Expression<Func<TChild, TProperty?>> propertyExpression, TProperty? value)
             where TProperty : struct, Enum
         {
             var property = propertyExpression.GetPropertyInfo();
@@ -77,7 +77,7 @@ namespace DataversePluginTemplate.Service.Entities
             _entity.Attributes[logicalName] = new OptionSetValue(Convert.ToInt32(value));
         }
 
-        public TProperty GetEnumArray<TProperty>(Expression<Func<TChild, TProperty>> propertyExpression)
+        protected TProperty GetEnumArray<TProperty>(Expression<Func<TChild, TProperty>> propertyExpression)
             where TProperty : class
         {
             var property = propertyExpression.GetPropertyInfo();
@@ -92,7 +92,7 @@ namespace DataversePluginTemplate.Service.Entities
             return enumArray as TProperty;
         }
 
-        public void SetEnumArray<TProperty>(Expression<Func<TChild, TProperty>> propertyExpression, TProperty value)
+        protected void SetEnumArray<TProperty>(Expression<Func<TChild, TProperty>> propertyExpression, TProperty value)
             where TProperty : class
         {
             var property = propertyExpression.GetPropertyInfo();

--- a/DataversePluginTemplate/Service/Entities/IncludableAttribute.cs
+++ b/DataversePluginTemplate/Service/Entities/IncludableAttribute.cs
@@ -8,5 +8,5 @@ namespace DataversePluginTemplate.Service.Entities
     /// and <see cref="Queries.IncludeContext{TInner, TOuter}"/>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
-    internal class IncludableAttribute : Attribute { }
+    public sealed class IncludableAttribute : Attribute { }
 }

--- a/DataversePluginTemplate/Service/Entities/LogicalNameAttribute.cs
+++ b/DataversePluginTemplate/Service/Entities/LogicalNameAttribute.cs
@@ -8,7 +8,7 @@ namespace DataversePluginTemplate.Service.Entities
     /// entities AttributeCollection and in queries or other database operations.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
-    internal sealed class LogicalNameAttribute : Attribute
+    public sealed class LogicalNameAttribute : Attribute
     {
         public string Name { get; }
 

--- a/DataversePluginTemplate/Service/Entities/NameAttribute.cs
+++ b/DataversePluginTemplate/Service/Entities/NameAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace DataversePluginTemplate.Service.Entities
 {
-    internal class NameAttribute : Attribute
+    public sealed class NameAttribute : Attribute
     {
         public string Name { get; private set; }
         public NameAttribute(string name) : base() 

--- a/DataversePluginTemplate/Service/Entities/PrimaryKeyAttribute.cs
+++ b/DataversePluginTemplate/Service/Entities/PrimaryKeyAttribute.cs
@@ -3,5 +3,5 @@
 namespace DataversePluginTemplate.Service.Entities
 {
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
-    internal sealed class PrimaryKeyAttribute : Attribute { }
+    public sealed class PrimaryKeyAttribute : Attribute { }
 }

--- a/DataversePluginTemplate/Service/Extensions/EntityExtensionMethods.cs
+++ b/DataversePluginTemplate/Service/Extensions/EntityExtensionMethods.cs
@@ -8,9 +8,9 @@ using System.Reflection;
 
 namespace DataversePluginTemplate.Service.Extensions
 {
-    internal static class EntityExtensionMethods
+    public static class EntityExtensionMethods
     {
-        internal static void SetPropertyValue<TEntity, TProperty, TValue>(this Entity entity, TEntity earlyBoundInstance, Expression<Func<TEntity, TProperty>> propertyExpression, TValue value)
+        public static void SetPropertyValue<TEntity, TProperty, TValue>(this Entity entity, TEntity earlyBoundInstance, Expression<Func<TEntity, TProperty>> propertyExpression, TValue value)
             where TEntity : Entity, new()
         {
             var logicalName = GetPropertyLogicalName(propertyExpression);
@@ -20,7 +20,7 @@ namespace DataversePluginTemplate.Service.Extensions
             entity[logicalName] = value;
         }
 
-        internal static TValue GetPropertyValue<TEntity, TProperty, TValue>(this Entity entity, TEntity earlyBoundInstance, Expression<Func<TEntity, TProperty>> propertyExpression)
+        public static TValue GetPropertyValue<TEntity, TProperty, TValue>(this Entity entity, TEntity earlyBoundInstance, Expression<Func<TEntity, TProperty>> propertyExpression)
             where TEntity : Entity, new()
             where TValue : class, new()
         {
@@ -31,7 +31,7 @@ namespace DataversePluginTemplate.Service.Extensions
             return entity[logicalName] as TValue;
         }
 
-        internal static T As<T>(this Entity entity)
+        public static T As<T>(this Entity entity)
             where T : BaseEntity<T>
         {
             // Konstruktor suchen
@@ -46,19 +46,19 @@ namespace DataversePluginTemplate.Service.Extensions
             return target;
         }
 
-        internal static IEnumerable<T> As<T>(this IEnumerable<Entity> entities)
+        public static IEnumerable<T> As<T>(this IEnumerable<Entity> entities)
             where T : BaseEntity<T>
         {
             return entities.Select(entity => entity.As<T>());
         }
 
-        internal static IEnumerable<T> As<T>(this EntityCollection entityCollection)
+        public static IEnumerable<T> As<T>(this EntityCollection entityCollection)
             where T : BaseEntity<T>
         {
             return entityCollection.Entities.As<T>();
         }
 
-        internal static void Update<T>(this BaseEntity<T> entity, PluginContext context, Action<T> configure)
+        public static void Update<T>(this BaseEntity<T> entity, PluginContext context, Action<T> configure)
             where T : BaseEntity<T>
         {
             var updateEntity = new Entity(entity.Entity.LogicalName, entity.Id)
@@ -69,7 +69,7 @@ namespace DataversePluginTemplate.Service.Extensions
             context.OrgService.Update(updateEntity.Entity);
         }
 
-        internal static void Update<T>(this T entity, PluginContext context, Expression<Func<T, object[]>> propertySelector)
+        public static void Update<T>(this T entity, PluginContext context, Expression<Func<T, object[]>> propertySelector)
             where T : BaseEntity<T>
         {
             var propertyInfos = propertySelector.GetPropertyInfos();
@@ -85,6 +85,20 @@ namespace DataversePluginTemplate.Service.Extensions
             }
 
             context.OrgService.Update(updateEntity);
+        }
+
+        public static void SetEntityValue<TEntity, TInput, TProp>(this TEntity entity, Expression<Func<TEntity, TProp>> propertySelector, TInput inputValue, bool? shouldClear)
+            where TEntity : BaseEntity<TEntity>
+        {
+            var propertyInfo = propertySelector.GetPropertyInfo();
+            if (shouldClear == true)
+                propertyInfo.SetValue(entity, null);
+
+            else
+            {
+                if (inputValue != null)
+                    propertyInfo.SetValue(entity, inputValue);
+            }
         }
 
         private static string GetPropertyLogicalName<TEntity, TProperty>(Expression<Func<TEntity, TProperty>> propertyExpression)
@@ -108,20 +122,6 @@ namespace DataversePluginTemplate.Service.Extensions
             catch
             {
                 return null;
-            }
-        }
-
-        internal static void SetEntityValue<TEntity, TInput, TProp>(this TEntity entity, Expression<Func<TEntity, TProp>> propertySelector, TInput inputValue, bool? shouldClear)
-            where TEntity : BaseEntity<TEntity>
-        {
-            var propertyInfo = propertySelector.GetPropertyInfo();
-            if (shouldClear == true)
-                propertyInfo.SetValue(entity, null);
-
-            else
-            {
-                if (inputValue != null)
-                    propertyInfo.SetValue(entity, inputValue);
             }
         }
     }

--- a/DataversePluginTemplate/Service/Extensions/EnumExtensionMethods.cs
+++ b/DataversePluginTemplate/Service/Extensions/EnumExtensionMethods.cs
@@ -3,9 +3,9 @@ using System.Reflection;
 
 namespace DataversePluginTemplate.Service.Extensions
 {
-    internal static class EnumExtensionMethods
+    public static class EnumExtensionMethods
     {
-        private static TAttribute GetCustomAttribute<TAttribute>(Enum enumValue)
+        public static TAttribute GetCustomAttribute<TAttribute>(Enum enumValue)
             where TAttribute : Attribute
         {
             var enumType = enumValue.GetType();

--- a/DataversePluginTemplate/Service/Extensions/InputExtensionMethods.cs
+++ b/DataversePluginTemplate/Service/Extensions/InputExtensionMethods.cs
@@ -5,16 +5,16 @@ using System.Reflection;
 
 namespace DataversePluginTemplate.Service.Extensions
 {
-    internal static class InputExtensionMethods
+    public static class InputExtensionMethods
     {
-        internal static bool IsValid(this Guid guid) => guid != null && guid != default && guid != Guid.Empty;
-        internal static bool IsValid(this Guid? guid) => guid != null && guid.HasValue && guid.Value != default && guid.Value != Guid.Empty;
+        public static bool IsValid(this Guid guid) => guid != null && guid != default && guid != Guid.Empty;
+        public static bool IsValid(this Guid? guid) => guid != null && guid.HasValue && guid.Value != default && guid.Value != Guid.Empty;
 
-        internal static bool IsValid(this DateTime dateTime) => dateTime != null && dateTime != default;
-        internal static bool IsValid(this DateTime? dateTime) => dateTime != null && dateTime.HasValue && dateTime.Value != default;
+        public static bool IsValid(this DateTime dateTime) => dateTime != null && dateTime != default;
+        public static bool IsValid(this DateTime? dateTime) => dateTime != null && dateTime.HasValue && dateTime.Value != default;
 
 
-        internal static DateTime GetUtcTime(this DateTime dateTime)
+        public static DateTime GetUtcTime(this DateTime dateTime)
         {
             var specifiedLocalTime = dateTime.Kind != DateTimeKind.Local
                 ? DateTime.SpecifyKind(dateTime, DateTimeKind.Local)

--- a/DataversePluginTemplate/Service/Extensions/OrganizationServiceExtensionMethods.cs
+++ b/DataversePluginTemplate/Service/Extensions/OrganizationServiceExtensionMethods.cs
@@ -13,9 +13,9 @@ using System.Reflection;
 
 namespace DataversePluginTemplate.Service.Extensions
 {
-    internal static class OrganizationServiceExtensionMethods
+    public static class OrganizationServiceExtensionMethods
     {
-        internal static ExecuteMultipleResponse ExecuteMultiple<TRequest>(
+        public static ExecuteMultipleResponse ExecuteMultiple<TRequest>(
             this IOrganizationService orgService,
             IEnumerable<TRequest> requests,
             Action<ExecuteMultipleRequest> configureRequest = null)
@@ -32,7 +32,7 @@ namespace DataversePluginTemplate.Service.Extensions
             return (ExecuteMultipleResponse)orgService.Execute(executeMultiRequest);
         }
 
-        internal static ExecuteMultipleResponse ExecuteMultiple<TRequest, TItem>(
+        public static ExecuteMultipleResponse ExecuteMultiple<TRequest, TItem>(
             this IOrganizationService orgService,
             IEnumerable<TItem> requestItems,
             Action<TRequest, TItem> configureRequestItem,
@@ -51,7 +51,7 @@ namespace DataversePluginTemplate.Service.Extensions
             return orgService.ExecuteMultiple<TRequest>(requests, configureRequest);
         }
 
-        internal static ExecuteMultipleResponse CreateMultiple(
+        public static ExecuteMultipleResponse CreateMultiple(
             this IOrganizationService orgService,
         IEnumerable<Entity> entities,
             Action<ExecuteMultipleRequest> configureRequest = null)
@@ -62,7 +62,7 @@ namespace DataversePluginTemplate.Service.Extensions
             }, configureRequest);
         }
 
-        internal static ExecuteMultipleResponse CreateMultiple(
+        public static ExecuteMultipleResponse CreateMultiple(
             this IOrganizationService orgService,
             IEnumerable<Entity> entities)
         {
@@ -73,7 +73,7 @@ namespace DataversePluginTemplate.Service.Extensions
             });
         }
 
-        internal static ExecuteMultipleResponse UpdateMultiple(
+        public static ExecuteMultipleResponse UpdateMultiple(
             this IOrganizationService orgService,
         IEnumerable<Entity> entities,
             Action<ExecuteMultipleRequest> configureRequest = null)
@@ -84,7 +84,7 @@ namespace DataversePluginTemplate.Service.Extensions
             }, configureRequest);
         }
 
-        internal static ExecuteMultipleResponse UpdateMultiple(
+        public static ExecuteMultipleResponse UpdateMultiple(
             this IOrganizationService orgService,
             IEnumerable<Entity> entities)
         {
@@ -95,7 +95,7 @@ namespace DataversePluginTemplate.Service.Extensions
             });
         }
 
-        internal static ExecuteMultipleResponse DeleteMultiple(
+        public static ExecuteMultipleResponse DeleteMultiple(
             this IOrganizationService orgService,
             IEnumerable<EntityReference> entityReferences,
             Action<ExecuteMultipleRequest> configureRequest = null)
@@ -106,7 +106,7 @@ namespace DataversePluginTemplate.Service.Extensions
             }, configureRequest);
         }
 
-        internal static ExecuteMultipleResponse DeleteMultiple(
+        public static ExecuteMultipleResponse DeleteMultiple(
             this IOrganizationService orgService,
             IEnumerable<EntityReference> entityReferences)
         {
@@ -119,45 +119,45 @@ namespace DataversePluginTemplate.Service.Extensions
 
         #region Retrieve Entities
 
-        internal static Entity Retrieve(this IOrganizationService orgService, EntityReference entityReference, params string[] columns)
+        public static Entity Retrieve(this IOrganizationService orgService, EntityReference entityReference, params string[] columns)
         {
             return orgService.Retrieve(entityReference, new ColumnSet(columns));
         }
-        internal static Entity Retrieve(this IOrganizationService orgService, EntityReference entityReference, bool allColumns = true)
+        public static Entity Retrieve(this IOrganizationService orgService, EntityReference entityReference, bool allColumns = true)
         {
             return orgService.Retrieve(entityReference, new ColumnSet(allColumns));
         }
-        internal static Entity Retrieve(this IOrganizationService orgService, EntityReference entityReference, ColumnSet columnSet)
+        public static Entity Retrieve(this IOrganizationService orgService, EntityReference entityReference, ColumnSet columnSet)
         {
             if (entityReference == null)
                 return null;
             return orgService.Retrieve(entityReference.LogicalName, entityReference.Id, columnSet);
         }
 
-        internal static Entity Retrieve(this IOrganizationService orgService, Entity entity, params string[] columns)
+        public static Entity Retrieve(this IOrganizationService orgService, Entity entity, params string[] columns)
         {
             return orgService.Retrieve(entity, new ColumnSet(columns));
         }
-        internal static Entity Retrieve(this IOrganizationService orgService, Entity entity, bool allColumns = true)
+        public static Entity Retrieve(this IOrganizationService orgService, Entity entity, bool allColumns = true)
         {
             return orgService.Retrieve(entity, new ColumnSet(allColumns));
         }
-        internal static Entity Retrieve(this IOrganizationService orgService, Entity entity, ColumnSet columnSet)
+        public static Entity Retrieve(this IOrganizationService orgService, Entity entity, ColumnSet columnSet)
         {
             if (entity == null)
                 return null;
             return orgService.Retrieve(entity.ToEntityReference(), columnSet);
         }
 
-        internal static Entity Retrieve(this IOrganizationService orgService, string entityName, Guid id, params string[] columns)
+        public static Entity Retrieve(this IOrganizationService orgService, string entityName, Guid id, params string[] columns)
         {
             return orgService.Retrieve(entityName, id, new ColumnSet(columns));
         }
-        internal static Entity Retrieve(this IOrganizationService orgService, string entityName, Guid id, bool allColumns = true)
+        public static Entity Retrieve(this IOrganizationService orgService, string entityName, Guid id, bool allColumns = true)
         {
             return orgService.Retrieve(entityName, id, new ColumnSet(allColumns));
         }
-        internal static Entity Retrieve(this IOrganizationService orgService, string entityName, Guid id, ColumnSet columnSet)
+        public static Entity Retrieve(this IOrganizationService orgService, string entityName, Guid id, ColumnSet columnSet)
         {
             if (id == null || string.IsNullOrWhiteSpace(entityName))
                 return null;
@@ -165,28 +165,28 @@ namespace DataversePluginTemplate.Service.Extensions
             return orgService.Retrieve(entityName, id, columnSet);
         }
 
-        internal static T Retrieve<T>(this IOrganizationService orgService, EntityReference entityReference, params string[] columns)
+        public static T Retrieve<T>(this IOrganizationService orgService, EntityReference entityReference, params string[] columns)
             where T : BaseEntity<T>
         {
             return orgService.Retrieve<T>(entityReference, new ColumnSet(columns));
         }
-        internal static T Retrieve<T>(this IOrganizationService orgService, EntityReference entityReference, bool allColumns)
+        public static T Retrieve<T>(this IOrganizationService orgService, EntityReference entityReference, bool allColumns)
             where T : BaseEntity<T>
         {
             return orgService.Retrieve<T>(entityReference, new ColumnSet(allColumns));
         }
-        internal static T Retrieve<T>(this IOrganizationService orgService, EntityReference entityReference, Columns columns = Columns.DefinedOnly)
+        public static T Retrieve<T>(this IOrganizationService orgService, EntityReference entityReference, Columns columns = Columns.DefinedOnly)
             where T : BaseEntity<T>
         {
             return orgService.Retrieve<T>(entityReference, GetColumnSet<T>(columns));
         }
-        internal static T Retrieve<T>(this IOrganizationService orgService, EntityReference entityReference, Expression<Func<T, object[]>> propertySelector)
+        public static T Retrieve<T>(this IOrganizationService orgService, EntityReference entityReference, Expression<Func<T, object[]>> propertySelector)
             where T : BaseEntity<T>
         {
             ColumnSet columnSet = GetFromPropertySelector(propertySelector);
             return orgService.Retrieve<T>(entityReference, columnSet);
         }
-        internal static T Retrieve<T>(this IOrganizationService orgService, EntityReference entityReference, ColumnSet columnSet)
+        public static T Retrieve<T>(this IOrganizationService orgService, EntityReference entityReference, ColumnSet columnSet)
             where T : BaseEntity<T>
         {
             if (entityReference == null)
@@ -196,17 +196,17 @@ namespace DataversePluginTemplate.Service.Extensions
             .As<T>();
         }
 
-        internal static T Retrieve<T>(this IOrganizationService orgService, Entity entity, params string[] columns)
+        public static T Retrieve<T>(this IOrganizationService orgService, Entity entity, params string[] columns)
             where T : BaseEntity<T>
         {
             return orgService.Retrieve<T>(entity, new ColumnSet(columns));
         }
-        internal static T Retrieve<T>(this IOrganizationService orgService, Entity entity, bool allColumns)
+        public static T Retrieve<T>(this IOrganizationService orgService, Entity entity, bool allColumns)
             where T : BaseEntity<T>
         {
             return orgService.Retrieve<T>(entity, new ColumnSet(allColumns));
         }
-        internal static T Retrieve<T>(this IOrganizationService orgService, Entity entity, Columns columns = Columns.DefinedOnly)
+        public static T Retrieve<T>(this IOrganizationService orgService, Entity entity, Columns columns = Columns.DefinedOnly)
             where T : BaseEntity<T>
         {
             return orgService.Retrieve<T>(entity, GetColumnSet<T>(columns));
@@ -214,13 +214,13 @@ namespace DataversePluginTemplate.Service.Extensions
 
         
 
-        internal static T Retrieve<T>(this IOrganizationService orgService, Entity entity, Expression<Func<T, object[]>> propertySelector)
+        public static T Retrieve<T>(this IOrganizationService orgService, Entity entity, Expression<Func<T, object[]>> propertySelector)
             where T : BaseEntity<T>
         {
             ColumnSet columnSet = GetFromPropertySelector(propertySelector);
             return orgService.Retrieve<T>(entity, columnSet);
         }
-        internal static T Retrieve<T>(this IOrganizationService orgService, Entity entity, ColumnSet columnSet)
+        public static T Retrieve<T>(this IOrganizationService orgService, Entity entity, ColumnSet columnSet)
             where T : BaseEntity<T>
         {
             if (entity == null)
@@ -229,29 +229,29 @@ namespace DataversePluginTemplate.Service.Extensions
             return orgService.Retrieve<T>(entity.ToEntityReference(), columnSet);
         }
 
-        internal static T Retrieve<T>(this IOrganizationService orgService, Guid id, params string[] columns)
+        public static T Retrieve<T>(this IOrganizationService orgService, Guid id, params string[] columns)
             where T : BaseEntity<T>
         {
             return orgService.Retrieve<T>(id, new ColumnSet(columns));
         }
-        internal static T Retrieve<T>(this IOrganizationService orgService, Guid id, bool allColumns)
+        public static T Retrieve<T>(this IOrganizationService orgService, Guid id, bool allColumns)
             where T : BaseEntity<T>
         {
             return orgService.Retrieve<T>(id, new ColumnSet(allColumns));
         }
 
-        internal static T Retrieve<T>(this IOrganizationService orgService, Guid id, Columns columns = Columns.DefinedOnly)
+        public static T Retrieve<T>(this IOrganizationService orgService, Guid id, Columns columns = Columns.DefinedOnly)
             where T : BaseEntity<T>
         {
             return orgService.Retrieve<T>(id, GetColumnSet<T>(columns));
         }
-        internal static T Retrieve<T>(this IOrganizationService orgService, Guid id, Expression<Func<T, object[]>> propertySelector)
+        public static T Retrieve<T>(this IOrganizationService orgService, Guid id, Expression<Func<T, object[]>> propertySelector)
             where T : BaseEntity<T>
         {
             ColumnSet columnSet = GetFromPropertySelector(propertySelector);
             return orgService.Retrieve<T>(id, columnSet);
         }
-        internal static T Retrieve<T>(this IOrganizationService orgService, Guid id, ColumnSet columnSet)
+        public static T Retrieve<T>(this IOrganizationService orgService, Guid id, ColumnSet columnSet)
             where T : BaseEntity<T>
         {
             if (id == null)
@@ -265,26 +265,26 @@ namespace DataversePluginTemplate.Service.Extensions
         #endregion
 
 
-        internal static QueryContext Select(
+        public static QueryContext Select(
             this IOrganizationService orgService,
             string entityName)
         {
             return new QueryContext(orgService, entityName);
         }
 
-        internal static QueryContext<T> Select<T>(this IOrganizationService orgService)
+        public static QueryContext<T> Select<T>(this IOrganizationService orgService)
             where T : BaseEntity<T>
         {
             return new QueryContext<T>(orgService);
         }
 
-        internal static void Update<T>(this IOrganizationService orgService, T entity)
+        public static void Update<T>(this IOrganizationService orgService, T entity)
             where T : BaseEntity<T>
         {
             orgService.Update(entity.Entity);
         }
 
-        internal static void Update<T>(this IOrganizationService orgService, T entity, Expression<Func<T, object[]>> properySelector)
+        public static void Update<T>(this IOrganizationService orgService, T entity, Expression<Func<T, object[]>> properySelector)
             where T : BaseEntity<T>
         {
             var updateEntity = new Entity(entity.Entity.LogicalName, entity.Id);
@@ -299,7 +299,7 @@ namespace DataversePluginTemplate.Service.Extensions
             orgService.Update(updateEntity);
         }
 
-        internal static TOutput SendRequest<TInput, TOutput>(this IOrganizationService orgService, BaseInputModel<TInput> input)
+        public static TOutput SendRequest<TInput, TOutput>(this IOrganizationService orgService, BaseInputModel<TInput> input)
             where TInput : BaseInputModel<TInput>, new()
             where TOutput : class, new()
         {
@@ -324,14 +324,14 @@ namespace DataversePluginTemplate.Service.Extensions
             return result;
         }
 
-        internal static byte[] DownloadImageColumn<T>(this IOrganizationService orgService, T target, Expression<Func<T, byte[]>> propertySelector)
+        public static byte[] DownloadImageColumn<T>(this IOrganizationService orgService, T target, Expression<Func<T, byte[]>> propertySelector)
             where T : BaseEntity<T>
         {
             var columnName = propertySelector.GetPropertyInfo().GetLogicalName();
             return DownloadImageColumn(orgService, target.Reference, columnName);
         }
 
-        internal static byte[] DownloadImageColumn(this IOrganizationService orgService, EntityReference targetReference, string columnName)
+        public static byte[] DownloadImageColumn(this IOrganizationService orgService, EntityReference targetReference, string columnName)
         {
             var initDownloadRequest = new InitializeFileBlocksDownloadRequest()
             {

--- a/DataversePluginTemplate/Service/Extensions/TracingServiceExtensionMethods.cs
+++ b/DataversePluginTemplate/Service/Extensions/TracingServiceExtensionMethods.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace DataversePluginTemplate.Service.Extensions
 {
-    internal static class TracingServiceExtensionMethods
+    public static class TracingServiceExtensionMethods
     {
 #if DEBUG
         public static void DebugLog(this ITracingService tracingService, string message)

--- a/DataversePluginTemplate/Service/Notification/Notification.cs
+++ b/DataversePluginTemplate/Service/Notification/Notification.cs
@@ -6,7 +6,7 @@ namespace DataversePluginTemplate.Service.Notification
     /// <summary>
     /// For sending dataverse notifications. Use the <see cref="Create"/> method to get started.
     /// </summary>
-    internal sealed class Notification
+    public sealed class Notification
     {
         private const string SYSTEMUSER_LOGICALNAME = "systemuser";
         private const string NOTIFICATIONID = "NotificationId";

--- a/DataversePluginTemplate/Service/Notification/NotificationIcon.cs
+++ b/DataversePluginTemplate/Service/Notification/NotificationIcon.cs
@@ -1,6 +1,6 @@
 ﻿namespace DataversePluginTemplate.Service.Notification
 {
-    internal enum NotificationIcon
+    public enum NotificationIcon
     {
         Info = 100000000,
         Success = 100000001,

--- a/DataversePluginTemplate/Service/Notification/NotificationType.cs
+++ b/DataversePluginTemplate/Service/Notification/NotificationType.cs
@@ -1,6 +1,6 @@
 ﻿namespace DataversePluginTemplate.Service.Notification
 {
-    internal enum NotificationType
+    public enum NotificationType
     {
         Timed = 200000000,
         Hidden = 200000001,

--- a/DataversePluginTemplate/Service/PluginContext.cs
+++ b/DataversePluginTemplate/Service/PluginContext.cs
@@ -14,17 +14,17 @@ namespace DataversePluginTemplate.Service
     {
         private readonly IServiceProvider _serviceProvider;
 
-        internal IPluginExecutionContext ExecutionContext { get; }
-        internal ITracingService TracingService { get; }
-        internal IServiceEndpointNotificationService NotificationService { get; }
-        internal ILogger Logger { get; }
-        internal IOrganizationService PluginUserService { get; }
-        internal IOrganizationService OrgService => PluginUserService;
-        internal IOrganizationService InitiatinUserService { get; }
-        internal PluginStage PluginStage { get; }
-        internal PluginExecutionMode ExecutionMode { get; }
+        public IPluginExecutionContext ExecutionContext { get; }
+        public ITracingService TracingService { get; }
+        public IServiceEndpointNotificationService NotificationService { get; }
+        public ILogger Logger { get; }
+        public IOrganizationService PluginUserService { get; }
+        public IOrganizationService OrgService => PluginUserService;
+        public IOrganizationService InitiatinUserService { get; }
+        public PluginStage PluginStage { get; }
+        public PluginExecutionMode ExecutionMode { get; }
 
-        internal PluginContext(IServiceProvider serviceProvider)
+        public PluginContext(IServiceProvider serviceProvider)
         {
             if (serviceProvider == null)
                 throw new InvalidPluginExecutionException(nameof(serviceProvider));
@@ -42,14 +42,14 @@ namespace DataversePluginTemplate.Service
             ExecutionMode = (PluginExecutionMode)ExecutionContext.Mode;
         }
 
-        internal PluginContext(IServiceProvider serviceProvider, Action<PluginContext> configureContext)
+        public PluginContext(IServiceProvider serviceProvider, Action<PluginContext> configureContext)
             : this(serviceProvider)
         {
             configureContext?.Invoke(this);
         }
 
 #if DEBUG
-        internal void DebugLog()
+        public void DebugLog()
         {
             TracingService.DebugLogSeparator("Plugin Context");
             TracingService.DebugLog(Environment.NewLine + GetContextLogStr(ExecutionContext));

--- a/DataversePluginTemplate/Service/PluginExecutionMode.cs
+++ b/DataversePluginTemplate/Service/PluginExecutionMode.cs
@@ -1,6 +1,6 @@
 ﻿namespace DataversePluginTemplate.Service
 {
-    internal enum PluginExecutionMode
+    public enum PluginExecutionMode
     {
         Synchronous = 0,
         Asynchronous = 1,

--- a/DataversePluginTemplate/Service/PluginStage.cs
+++ b/DataversePluginTemplate/Service/PluginStage.cs
@@ -1,6 +1,6 @@
 ﻿namespace DataversePluginTemplate.Service
 {
-    internal enum PluginStage
+    public enum PluginStage
     {
         PreValidation = 10,
         PreOperation = 20,


### PR DESCRIPTION
Changed access modifers of classes, enums, properties, etc.
The change allows to use the contents from different projects, that reference the library.

Related issue #26 